### PR TITLE
Additional fixes for implicit surfaces (develop)

### DIFF
--- a/3rd/ANN/CMakeLists.txt
+++ b/3rd/ANN/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 2.6)
+
+# Include this file for standard build settings
+include("../../cmake/buildCoreComponents.cmake")
+
+
+# "Normal" ANN
+project(ANN)
+
+set(SOURCES
+	ANN.cpp
+	bd_fix_rad_search.cpp
+	bd_pr_search.cpp
+	bd_search.cpp
+	bd_tree.cpp
+	brute.cpp
+	kd_dump.cpp
+	kd_fix_rad_search.cpp
+	kd_pr_search.cpp
+	kd_search.cpp
+	kd_split.cpp
+	kd_tree.cpp
+	kd_util.cpp
+	perf.cpp)
+
+set(PUBLIC_HEADERS
+	ANN.h
+	ANNperf.h
+	ANNx.h
+	bd_tree.h
+	kd_fix_rad_search.h
+	kd_pr_search.h
+	kd_search.h
+	kd_split.h
+	kd_tree.h
+	kd_util.h
+	pr_queue.h
+	pr_queue_k.h)
+
+include_directories(./..)
+
+cgv_add_3rd_library(ANN
+	SOURCES ${SOURCES}
+	PUBLIC_HEADERS ${PUBLIC_HEADERS}
+	SHARED_DEFINITIONS "DLL_EXPORTS" "ANN_PERF" "ANN_NO_RANDOM"
+	STATIC_DEFINITIONS "ANN_STATIC" "ANN_NO_RANDOM")
+
+cgv_write_find_file(ANN)
+
+
+# Float version of ANN
+project(ANNf)
+
+include_directories(./..)
+
+cgv_add_3rd_library(ANNf
+	SOURCES ${SOURCES}
+	PUBLIC_HEADERS ${PUBLIC_HEADERS}
+	SHARED_DEFINITIONS "DLL_EXPORTS" "ANN_PERF" "ANN_NO_RANDOM" "ANN_USE_FLOAT"
+	STATIC_DEFINITIONS "ANN_STATIC" "ANN_NO_RANDOM" "ANN_USE_FLOAT")
+
+cgv_write_find_file(ANNf)

--- a/3rd/ANN/kd_dump.cpp
+++ b/3rd/ANN/kd_dump.cpp
@@ -31,6 +31,11 @@
 // desired.)
 //----------------------------------------------------------------------
 
+// --- [CGV Framework] -------------------------------------------------
+// - make it compile with GCC
+#include <cstring>
+// --- [/CGV Framework] ------------------------------------------------
+
 #include "kd_tree.h"					// kd-tree declarations
 #include "bd_tree.h"					// bd-tree declarations
 

--- a/3rd/CMakeLists.txt
+++ b/3rd/CMakeLists.txt
@@ -51,6 +51,7 @@ endmacro()
 
 set(depslist "")
 
+#check_3rd_package(ANN ann depslist)
 check_3rd_package(ZLIB zlib depslist)
 check_3rd_package(GLEW glew depslist)
 # check_3rd_package(PNG png depslist)
@@ -59,6 +60,7 @@ check_3rd_package(TIFF tiff depslist)
 # check_3rd_package(FLTK2 fltk depslist)
 
 # Always use our modified bastard version
+add_subdirectory(ANN)
 # add_subdirectory(glew)
 add_subdirectory(png)
 # add_subdirectory(jpeg)

--- a/libs/cgv_gl/gl/gl_implicit_surface_drawable_base.cxx
+++ b/libs/cgv_gl/gl/gl_implicit_surface_drawable_base.cxx
@@ -509,7 +509,8 @@ void gl_implicit_surface_drawable_base::draw_implicit_surface(context& ctx)
 	if (outofdate) {
 		extract_mesh();
 		mri.destruct(ctx);
-		mri.construct(ctx, mesh);
+		if (mesh.get_nr_faces() > 0)
+			mri.construct(ctx, mesh);
 		outofdate = false;
 	}
 	if (wireframe) {
@@ -519,7 +520,8 @@ void gl_implicit_surface_drawable_base::draw_implicit_surface(context& ctx)
 		ctx.ref_default_shader_program().disable(ctx);
 	}
 	else {
-		mri.render_mesh(ctx, material);
+		if (mesh.get_nr_faces() > 0)
+			mri.render_mesh(ctx, material);
 	}
 }
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -9,16 +9,16 @@ add_subdirectory(cg_icons)
 add_subdirectory(cg_ext)
 add_subdirectory(crg_light)
 
-if(${BUILD_EXAMPLE_PLUGIN})
+if(BUILD_EXAMPLE_PLUGIN)
 	add_subdirectory(examples)
-endif(${BUILD_EXAMPLE_PLUGIN})
+endif()
 
 add_custom_target(plugins)
-if(${BUILD_EXAMPLE_PLUGIN})
+if(BUILD_EXAMPLE_PLUGIN)
 	add_dependencies(plugins cg_fltk crg_grid crg_stereo_view cmi_io cg_icons cg_ext crg_light examples)
-else(${BUILD_EXAMPLE_PLUGIN})
+else()
 	add_dependencies(plugins cg_fltk crg_grid crg_stereo_view cmi_io cg_icons cg_ext crg_light)
-endif(${BUILD_EXAMPLE_PLUGIN})
+endif()
 
 set_target_properties(plugins PROPERTIES FOLDER "${FOLDER_NAME_TOPLEVEL}")
 

--- a/plugins/examples/CMakeLists.txt
+++ b/plugins/examples/CMakeLists.txt
@@ -47,7 +47,7 @@ cgv_test_shaders(examples ${SHADER_SOURCES})
 set_target_properties(examples PROPERTIES FOLDER "${FOLDER_NAME_APPLICATION_PLUGINS}")
 
 cgv_get_viewer_locations(VIEWER_EXE VIEWER_DEBUG_EXE)
-set_target_properties(examples PROPERTIES VS_DEBUGGER_COMMAND_ARGUMENTS "plugin:cg_fltk plugin:crg_stereo_view plugin:crg_antialias plugin:crg_depth_of_field plugin:crg_light plugin:cg_ext plugin:cg_icons plugin:cg_meta plugin:cmi_io plugin:cmv_avi plugin:crg_grid plugin:co_web plugin:examples gui:$(CGV_DIR)/plugins/examples/examples.gui config:$(CGV_DIR)/plugins/examples/config.def type(shader_config):shader_path='$(CGV_DIR)/plugins/examples;$(CGV_DIR)/libs/plot/glsl;$(CGV_DIR)/libs/cgv_gl/glsl'")
+set_target_properties(examples PROPERTIES VS_DEBUGGER_COMMAND_ARGUMENTS "plugin:cg_fltk plugin:crg_stereo_view plugin:crg_antialias plugin:crg_depth_of_field plugin:crg_light plugin:cg_ext plugin:cg_icons plugin:cg_meta plugin:cmi_io plugin:cmv_avi plugin:crg_grid plugin:co_web plugin:examples gui:${CGV_DIR}/plugins/examples/examples.gui config:${CGV_DIR}/plugins/examples/config.def type(shader_config):shader_path='${CGV_DIR}/plugins/examples;${CGV_DIR}/libs/plot/glsl;${CGV_DIR}/libs/cgv_gl/glsl'")
 set_target_properties(examples PROPERTIES VS_DEBUGGER_COMMAND $<IF:$<CONFIG:Debug>,${VIEWER_DEBUG_EXE},${VIEWER_EXE}>)
 
 cgv_write_find_file(examples)

--- a/tool/shader_test/shader_test.cxx
+++ b/tool/shader_test/shader_test.cxx
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <fstream>
+#include <cgv/base/register.h>
 #include <cgv/render/context.h>
 #include <cgv/render/shader_code.h>
 #include <cgv/render/shader_program.h>
@@ -15,9 +16,21 @@
 #include <fltk/run.h>
 #endif
 
+using namespace cgv::base;
 using namespace cgv::render;
 using namespace cgv::utils::file;
 using namespace cgv::utils;
+
+
+// Disable registration debugging for more concise shader_test output
+struct global_regdebug_disabler
+{
+	global_regdebug_disabler()
+	{
+		disable_registration_debugging();
+	}
+} grdd_instance;
+
 
 int perform_test();
 
@@ -91,7 +104,7 @@ struct fltk_gl_context : public gl::gl_context, public fltk::GlWindow
 	void draw() 
 	{
 		int exit_code = perform_test();
-		exit(0);
+		exit(exit_code);
 	}
 };
 #endif

--- a/tool/shader_test/shader_testMacros.cmake
+++ b/tool/shader_test/shader_testMacros.cmake
@@ -29,10 +29,11 @@ macro(shader_command_add target infile)
 	if (NOT EXISTS "${LOG_PATH}")
 		file(MAKE_DIRECTORY "${LOG_PATH}")
 	endif()
+	get_target_property(SHADER_TEST_COMMAND ${shader_test_EXECUTABLE} LOCATION_${CONFIG})
 	add_custom_target(shader_test_${LOG_NAME}
-		DEPENDS "${INFILE_ABS}"
+		DEPENDS ${shader_test_EXECUTABLE} "${INFILE_ABS}"
 		SOURCES "${INFILE_ABS}"
-		COMMAND ${shader_test_EXECUTABLE} "${INFILE_ABS}" "${outfile}"
+		COMMAND ${CMAKE_COMMAND} -E env "CGV_DIR=${CGV_DIR}" "CGV_OPTIONS=SHADER_DEVELOPER" ${SHADER_TEST_COMMAND} "${INFILE_ABS}" "${outfile}"
 		COMMENT "Testing shader code in ${LOG_NAME}")
 
 	add_dependencies(${target} shader_test_${LOG_NAME})


### PR DESCRIPTION
ANN/ANNf need a CMakeLists.txt, and empty meshes were crashing gl_implicit_surface_drawable_base