### PR TITLE
Fix wrong side being indicated to compute_reflected_appearance for computed normal

### DIFF
--- a/libs/cgv_gl/glsl/spline_tube.glfs
+++ b/libs/cgv_gl/glsl/spline_tube.glfs
@@ -510,6 +510,6 @@ void main()
 	vec4 depth = get_projection_matrix() * v_eye;
 	gl_FragDepth = 0.5*(depth.z / depth.w) + 0.5;
 
-	frag_color = compute_reflected_appearance(hit_pos_eye, hit.normal, frag_color, 0);
+	frag_color = compute_reflected_appearance(hit_pos_eye, hit.normal, frag_color, 1);
 	finish_fragment(frag_color);
 }


### PR DESCRIPTION
As the title says - fixes inverted normal being used for two-sided illumination as well as flipped application of color mapping to front and back side of the tube.