### PR TITLE
Switched order of vertex shader attributes

### DIFF
--- a/libs/cgv_gl/glsl/spline_tube.glvs
+++ b/libs/cgv_gl/glsl/spline_tube.glvs
@@ -1,10 +1,10 @@
 #version 460 
 
 in vec4 position;
-in vec4 tangent;
 in float radius;
 in vec4 color;
 in int group_index;
+in vec4 tangent;
 
 out flat vec4 tangent_gs;
 out flat vec4 color_gs;


### PR DESCRIPTION
This allows the spline tube renderer to be used together with the rounded cone renderer by just connecting them via an attribute_array_manager.
The shader location location is used inside the aam to save state about the associated data. If both shaders use the same locations for their attributes, then the data will also match.