### PR TITLE
Varios quality of life improvements

### DIFF
--- a/cgv/media/image/image_reader.cxx
+++ b/cgv/media/image/image_reader.cxx
@@ -111,9 +111,8 @@ std::string image_reader::construct_filter_string()
 /// return a reference to the last error message
 const std::string& image_reader::get_last_error() const
 {
-	static std::string dummy;
 	if (!rd)
-		return dummy;
+		return last_error;
 	return rd->get_last_error();
 }
 
@@ -147,12 +146,20 @@ bool image_reader::open(const std::string& file_name)
 		return false;
 	std::string ext = to_lower(file_name.substr(pos+1));
 	std::vector<base_ptr>& readers = reader_listener::ref_readers();
+	std::stringstream all_supported_extensions = {};
 	for (unsigned int i=0; i<readers.size(); ++i) {
-		if (cgv::utils::is_element(ext, readers[i]->get_interface<abst_image_reader>()->get_supported_extensions())) {
+		if (i != readers.size() - 1) {
+            all_supported_extensions << ":";
+		}
+		const std::string &supported_extensions = readers[i]->get_interface<abst_image_reader>()->get_supported_extensions();
+		all_supported_extensions << supported_extensions;
+		if (cgv::utils::is_element(ext, supported_extensions)) {
 			rd = readers[i]->get_interface<abst_image_reader>()->clone();
 			return rd->open(file_name, *file_format_ptr, palette_formats);
 		}
 	}
+	last_error = "could not find a suitable reader for " + file_name + " (supported formats are " +
+				 all_supported_extensions.str() + ")";
 	return false;
 }
 

--- a/cgv/media/image/image_reader.h
+++ b/cgv/media/image/image_reader.h
@@ -68,6 +68,8 @@ protected:
 	std::vector<data_format>* palette_formats;
 	/// store a pointer to the chosen reader
 	abst_image_reader* rd;
+	/// last error message in case no reader is available
+	std::string last_error;
 	/// abstract interface for the setter, by default it simply returns false
 	bool set_void(const std::string& property, const std::string& type, const void* value);
 	/// abstract interface for the getter, by default it simply returns false

--- a/cgv/render/context.h
+++ b/cgv/render/context.h
@@ -254,7 +254,7 @@ public:
 	/// initialize members
 	render_component();
 	/// return whether component has been created
-	bool is_created() const;
+	virtual bool is_created() const;
 	/// copy the rendering api specific id the component to the memory location of the given pointer. 
 	/// For opengl this the passed pointer should be of type GLint or GLuint.
 	void put_id_void(void* ptr) const;

--- a/cgv/render/render_buffer.cxx
+++ b/cgv/render/render_buffer.cxx
@@ -33,16 +33,17 @@ bool render_buffer::is_created() const
 	return handle != 0;
 }
 
-void render_buffer::create(const context& ctx, int _width, int _height)
+bool render_buffer::create(const context& ctx, int _width, int _height)
 {
 	if (ctx_ptr)
 		destruct(*ctx_ptr);
 	else
 		destruct(ctx);
-	ctx.render_buffer_create(*this, *this, _width, _height);
+	bool res = ctx.render_buffer_create(*this, *this, _width, _height);
 	ctx_ptr = &ctx;
 	width = _width;
 	height = _height;
+	return res;
 }
 
 bool render_buffer::is_depth_buffer() const

--- a/cgv/render/render_buffer.h
+++ b/cgv/render/render_buffer.h
@@ -16,6 +16,8 @@ class CGV_API render_buffer
 {
 	int width, height;
 public:
+	using render_component::last_error;
+
 	/// construct from description of component format, where the default format specifies a color buffer with alpha channel
 	render_buffer(const std::string& description = "[R,G,B,A]");
 	/// destruct the render buffer
@@ -24,7 +26,7 @@ public:
 	    If no extent is specified it is copied from the current viewport. */
 	void create(const context& ctx, int width = -1, int height = -1);
 	/// check whether the buffer has been created
-	bool is_created() const;
+	bool is_created() const override;
 	/// calls the destruct method if necessary
 	~render_buffer();
 	/// return the width in pixels of the buffer

--- a/cgv/render/render_buffer.h
+++ b/cgv/render/render_buffer.h
@@ -24,7 +24,7 @@ public:
 	void destruct(const context& ctx);
 	/** create a render buffer. 
 	    If no extent is specified it is copied from the current viewport. */
-	void create(const context& ctx, int width = -1, int height = -1);
+	bool create(const context& ctx, int width = -1, int height = -1);
 	/// check whether the buffer has been created
 	bool is_created() const override;
 	/// calls the destruct method if necessary

--- a/cgv/render/texture.h
+++ b/cgv/render/texture.h
@@ -18,6 +18,8 @@ protected:
 	int  tex_unit;
 	bool complete_create(const context& ctx, bool created);
 public:
+	using render_component::last_error;
+
 	/**@name methods that can be called without context */
 	//@{
 	/** construct from description string (which defaults to rgba format)


### PR DESCRIPTION
- added `using render_component::last_error` to texture and render_buffer (this makes the usage of that field a lot easier)
- made `render_buffer::create` consistent with all the other API methods
- added last_error to image_reader, which will now give a more descriptive error message, in case an image file could not be loaded