### PR TITLE
Increased minimum required CMake version

### DIFF
--- a/3rd/fltk/CMakeLists.txt
+++ b/3rd/fltk/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(fltk)
 

--- a/3rd/glew/CMakeLists.txt
+++ b/3rd/glew/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(glew)
 

--- a/3rd/jpeg/CMakeLists.txt
+++ b/3rd/jpeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(jpeg)
 

--- a/3rd/json/CMakeLists.txt
+++ b/3rd/json/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(json)
 

--- a/3rd/png/CMakeLists.txt
+++ b/3rd/png/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(png)
 

--- a/3rd/tiff/CMakeLists.txt
+++ b/3rd/tiff/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(tif)
 

--- a/3rd/webserver/CMakeLists.txt
+++ b/3rd/webserver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(webserver)
 

--- a/3rd/zlib/CMakeLists.txt
+++ b/3rd/zlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(zlib)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 project(cgv)
 


### PR DESCRIPTION
Version 3.15 eliminates this warning of the Microsoft compiler: `Command line warning D9025 : overriding '/W3' with '/w'`
Note: A recent Ubuntu installation (20.10) has CMake version 3.16 installed.