### PR TITLE
Adjust drop_extension method to correctly work on paths without one

### DIFF
--- a/cgv/utils/file.cxx
+++ b/cgv/utils/file.cxx
@@ -563,6 +563,13 @@ std::string get_extension(const std::string& file_path)
 /// return the file path and name without extension
 std::string drop_extension(const std::string& file_path)
 {
+	// If there is no extension, the original path can be returned directly
+	// As paths can also contain dots (relative paths), we need to check the base name specifically, not the entire path
+	std::string base_name = get_file_name(file_path);
+	size_t pos = base_name.find_last_of('.');
+	if (pos == std::string::npos)
+		return file_path;
+
 	return file_path.substr(0,file_path.find_last_of('.'));
 }
 


### PR DESCRIPTION
Executables on Linux often do not have an extension. Using a standalone build on Linux means the application is looking for a "path" + ".cfg" file to load. However in the case of the path being "./my_application" for example, the old method would have returned an empty string.


The same issue can also happen on Windows, if a path like "C:/user/.mysecret/binaryblob" is used, where without the change "C:/user/" would be returned.